### PR TITLE
Merge pic stable into main

### DIFF
--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -31,6 +31,7 @@ on:
   push:
     branches:
       - main
+      - pic-stable
     tags: [v*]
 
 jobs:
@@ -40,13 +41,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image_name: sartography/spiffworkflow-frontend
+          - image_name: gsa-tts/spiffworkflow-frontend
             context: spiffworkflow-frontend
             description: "Frontend component of SpiffWorkflow, a software development platform for building, running, and monitoring executable diagrams"
-          - image_name: sartography/spiffworkflow-backend
+          - image_name: gsa-tts/spiffworkflow-backend
             context: spiffworkflow-backend
             description: "Backend component of SpiffWorkflow, a software development platform for building, running, and monitoring executable diagrams"
-          - image_name: sartography/connector-proxy-demo
+          - image_name: gsa-tts/connector-proxy-demo
             context: connector-proxy-demo
             description: "Connector proxy component of SpiffWorkflow, providing integration capabilities for external services"
 

--- a/spiffworkflow-backend/bin/wait_for_db_schema_migrations
+++ b/spiffworkflow-backend/bin/wait_for_db_schema_migrations
@@ -16,8 +16,8 @@ while true; do
     break
   else
     echo "Waiting for db migrations to finish"
-    echo "current revision: ${current_db_migration_head}"
-    echo "head revision: ${current_db_migration_revision}"
+    echo "current revision: ${current_db_migration_revision}"
+    echo "head revision: ${current_db_migration_head}"
     sleep 2
   fi
 done

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/monitoring_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/monitoring_service.py
@@ -100,7 +100,7 @@ def configure_sentry(app: flask.app.Flask) -> None:
         "traces_sampler": traces_sampler,
         # The profiles_sample_rate setting is relative to the traces_sample_rate setting.
         "before_send": before_send,
-        "auto_enabling_integrations": False, # We are seeing an OpenAI agents error. Just testing to see if this resolves it.
+        "auto_enabling_integrations": False,  # We are seeing an OpenAI agents error. Just testing to see if this resolves it.
     }
 
     # https://docs.sentry.io/platforms/python/configuration/releases

--- a/spiffworkflow-backend/src/spiffworkflow_backend/services/monitoring_service.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/services/monitoring_service.py
@@ -100,6 +100,7 @@ def configure_sentry(app: flask.app.Flask) -> None:
         "traces_sampler": traces_sampler,
         # The profiles_sample_rate setting is relative to the traces_sample_rate setting.
         "before_send": before_send,
+        "auto_enabling_integrations": False, # We are seeing an OpenAI agents error. Just testing to see if this resolves it.
     }
 
     # https://docs.sentry.io/platforms/python/configuration/releases


### PR DESCRIPTION
Begin to address our divergent branches by merging `pic-stable` into main.

Then we still need to merge in:
- burton/pic-stable: for local IDP changes needed for Playwright tests
- pic-test: to allow the sartography's init bootstrap script to run in docker not just ci.