### PR TITLE
Changes to merge back upstream

### DIFF
--- a/spiffworkflow-backend/bin/boot_server_in_docker
+++ b/spiffworkflow-backend/bin/boot_server_in_docker
@@ -102,6 +102,8 @@ if [[ "${SPIFFWORKFLOW_BACKEND_RUN_DATA_SETUP:-}" != "false" ]]; then
   uv run python bin/refresh_all_caches.py
 fi
 
+uv run python bin/bootstrap.py
+
 log_info "Starting gunicorn server"
 export IS_GUNICORN="true"
 # THIS MUST BE THE LAST COMMAND!

--- a/spiffworkflow-backend/bin/wait_for_db_schema_migrations
+++ b/spiffworkflow-backend/bin/wait_for_db_schema_migrations
@@ -16,8 +16,8 @@ while true; do
     break
   else
     echo "Waiting for db migrations to finish"
-    echo "current revision: ${current_db_migration_head}"
-    echo "head revision: ${current_db_migration_revision}"
+    echo "current revision: ${current_db_migration_revision}"
+    echo "head revision: ${current_db_migration_head}"
     sleep 2
   fi
 done

--- a/spiffworkflow-backend/src/spiffworkflow_backend/routes/openid_blueprint/openid_blueprint.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/routes/openid_blueprint/openid_blueprint.py
@@ -131,6 +131,7 @@ def token() -> Response:
         {
             "iss": f"{host_url}{url_for('openid.index')}",
             "aud": client_id,
+            "azp": client_id[0],
             "iat": math.floor(time.time()),
             "exp": round(time.time()) + two_days,
             "sub": user_name,
@@ -145,6 +146,7 @@ def token() -> Response:
         "access_token": id_token,
         "id_token": id_token,
         "refresh_token": id_token,
+        "token_type": "Bearer",
     }
     return make_response(jsonify(response), 200)
 


### PR DESCRIPTION
Includes changes to merge back upstream from:

- burton/pic-stable (local IDP changes needed for test)
- pic-test (to give same init users/process functionality to local docker)
- log naming mismatch in db migrations (discovered during debugging)

Once we get this merged into `main` in our fork, we can PR it back upstream.