### PR TITLE
Adds new test user seed group

### DIFF
--- a/spiffworkflow-backend/Dockerfile
+++ b/spiffworkflow-backend/Dockerfile
@@ -1,5 +1,5 @@
 # Base image to share ENV vars that activate VENV.
-FROM python:3.13.7-slim-trixie AS base
+FROM python:3.13-slim-trixie AS base
 
 ENV UV_NO_SYNC=true
 ENV VIRTUAL_ENV=/app/venv
@@ -24,6 +24,7 @@ FROM base AS deployment
 # jq because it is really useful, even for scenarios where people might have environment variables with json values they might need to use for configs. about 1MB.
 # libpq5 in order to be able to use postgres at runtime
 RUN apt-get update \
+  && apt-get upgrade -y -q \
   && apt-get clean -y \
   && apt-get install -y -q git-core curl procps default-mysql-client vim-tiny jq libpq5 libkrb5support0 libexpat1 \
   && rm -rf /var/lib/apt/lists/*
@@ -46,6 +47,7 @@ RUN pip install uv==0.6.16
 # default-libmysqlclient-dev for mysqlclient lib
 # libpq-dev in order to be able to install postgres lib, psycopg2. See also libpq5 above in deployment image.
 RUN apt-get update \
+  && apt-get upgrade -y -q \
   && apt-get install -y -q gcc git libssl-dev libpq-dev default-libmysqlclient-dev pkg-config libffi-dev
 
 COPY . /app

--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/permissions/pic_test.yml
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/permissions/pic_test.yml
@@ -36,11 +36,11 @@ groups:
   admin:
     users: [ admin@example.com, adminX@bootstrap, specialist@example.com ]
   blm-moab-ao:
-    users: [ admin@example.com, approver@example.com ]
+    users: [ approver@example.com ]
   blm-moab-nepa-coord:
-    users: [ admin@example.com, reviewer@example.com ]
+    users: [ reviewer@example.com ]
   blm-moab-supervisors:
-    users: [ admin@example.com, supervisor@example.com ]
+    users: [ supervisor@example.com ]
 
 permissions:
   # Admins have access to everything.

--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/permissions/pic_test.yml
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/permissions/pic_test.yml
@@ -1,0 +1,89 @@
+users:
+  approver:
+    service: local_open_id
+    email: approver@example.com
+    password: approver
+    preferred_username: approver
+  specialist:
+    service: local_open_id
+    email: specialist@example.com
+    password: specialist
+    preferred_username: specialist
+  reviewer:
+    service: local_open_id
+    email: reviewer@example.com
+    password: reviewer
+    preferred_username: reviewer
+  supervisor:
+    service: local_open_id
+    email: supervisor@example.com
+    password: supervisor
+    preferred_username: supervisor
+  analyst:
+    service: local_open_id
+    email: analyst@example.com
+    password: analyst
+    preferred_username: analyst
+  ogc:
+    service: local_open_id
+    email: ogc@example.com
+    password: ogc
+    preferred_username: ogc
+  proponent:
+    service: local_open_id
+    email: proponent@example.com
+    password: proponent
+    preferred_username: proponent
+  admin:
+    service: local_open_id
+    email: admin@example.com
+    password: admin
+    preferred_username: admin
+  adminX:
+    service: bootstrap
+
+groups:
+  admin:
+    users: [ admin@example.com, adminX@bootstrap ]
+  approver:
+    users: [ admin@example.com, approver@example.com ]
+  specialist:
+    users: [ admin@example.com, specialist@example.com ]
+  reviewer:
+    users: [ admin@example.com, reviewer@example.com ]
+  supervisor:
+    users: [ admin@example.com, supervisor@example.com ]
+  analyst:
+    users: [ admin@example.com, analyst@example.com ]
+  ogc:
+    users: [ admin@example.com, ogc@example.com ]
+  proponent:
+    users: [ admin@example.com, proponent@example.com ]
+
+permissions:
+  # Admins have access to everything.
+  admin:
+    groups: [ admin ]
+    actions: [ all ]
+    uri: /*
+
+  # Everybody can participate in tasks assigned to them.
+  # BASIC, PG, PM, are documented at https://spiff-arena.readthedocs.io/en/latest/DevOps_installation_integration/permission_url.html
+  basic:
+    groups: [ everybody ]
+    actions: [ all ]
+    uri: BASIC
+
+  # Everyone can see everything (all groups, and processes are visible)
+  read-all-process-groups:
+    groups: [ everybody ]
+    actions: [ read ]
+    uri: PG:ALL
+  read-all-process-models:
+    groups: [ everybody ]
+    actions: [ read ]
+    uri: PM:ALL
+  run-all-process-models:
+    groups: [ everybody ]
+    actions: [ start ]
+    uri: PM:ALL

--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/permissions/pic_test.yml
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/permissions/pic_test.yml
@@ -24,16 +24,6 @@ users:
     email: analyst@example.com
     password: analyst
     preferred_username: analyst
-  ogc:
-    service: local_open_id
-    email: ogc@example.com
-    password: ogc
-    preferred_username: ogc
-  proponent:
-    service: local_open_id
-    email: proponent@example.com
-    password: proponent
-    preferred_username: proponent
   admin:
     service: local_open_id
     email: admin@example.com
@@ -44,21 +34,13 @@ users:
 
 groups:
   admin:
-    users: [ admin@example.com, adminX@bootstrap ]
-  approver:
+    users: [ admin@example.com, adminX@bootstrap, specialist@example.com ]
+  blm-moab-ao:
     users: [ admin@example.com, approver@example.com ]
-  specialist:
-    users: [ admin@example.com, specialist@example.com ]
-  reviewer:
+  blm-moab-nepa-coord:
     users: [ admin@example.com, reviewer@example.com ]
-  supervisor:
+  blm-moab-supervisors:
     users: [ admin@example.com, supervisor@example.com ]
-  analyst:
-    users: [ admin@example.com, analyst@example.com ]
-  ogc:
-    users: [ admin@example.com, ogc@example.com ]
-  proponent:
-    users: [ admin@example.com, proponent@example.com ]
 
 permissions:
   # Admins have access to everything.

--- a/spiffworkflow-frontend/Dockerfile
+++ b/spiffworkflow-frontend/Dockerfile
@@ -1,5 +1,5 @@
 # Base image to share ENV vars that activate VENV.
-FROM node:24.10.0-trixie-slim AS base
+FROM node:24-trixie-slim AS base
 
 RUN mkdir /app
 
@@ -9,6 +9,7 @@ WORKDIR /app
 # procps for debugging
 # vim ftw
 RUN apt-get update \
+  && apt-get upgrade -y -q \
   && apt-get clean -y \
   && apt-get install -y -q \
   curl \
@@ -42,14 +43,13 @@ RUN ./bin/build
 
 # Use nginx as the base image
 # FROM nginx:1.29.1-bookworm
-FROM nginx:1.29.2-alpine
+FROM nginx:1-alpine
 
 # we sort of love bash too much to use sh
 RUN apk add --no-cache bash
 
-# to fix security vulnerability:
-# remove this line once the base image has the secure version of this lib (10.46)
-RUN apk add --upgrade pcre2
+# Upgrade all packages to fix security vulnerabilities
+RUN apk update && apk upgrade
 
 # Remove default nginx configuration
 RUN rm -rf /etc/nginx/conf.d/*


### PR DESCRIPTION
This adds `pic_test` user group to the deploy image that can be loaded in as the seed users in a GH Actions test run.

NOTE: I had to add an apt-upgrade to the Dockerfiles to get Sartography's Trivy tests to pass. I expect they'll need to do so over on the Sartography side as well.