### PR TITLE
Remove specialist from admin group in pic_test

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/permissions/pic_test.yml
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/permissions/pic_test.yml
@@ -34,7 +34,9 @@ users:
 
 groups:
   admin:
-    users: [ admin@example.com, adminX@bootstrap, specialist@example.com ]
+    users: [ admin@example.com, adminX@bootstrap ]
+  blm-moab:
+    users: [ specialist@example.com ]
   blm-moab-ao:
     users: [ approver@example.com ]
   blm-moab-nepa-coord:


### PR DESCRIPTION
See https://github.com/GSA-TTS/pic-blm-cxworks/pull/618

This PR need not be merged in any order; i.e., it does not need to be correlated with the above linked PR. Our tests should pass either way. That said, we should update to the new image ref once this is merged.