### PR TITLE
Cherry pick users assigned to task

### DIFF
--- a/docs/reference/bpmn/script_tasks.md
+++ b/docs/reference/bpmn/script_tasks.md
@@ -166,6 +166,7 @@ Please see the [implementing files themselves](https://github.com/sartography/sp
 | get_all_permissions                    | Gets all permissions currently in the system.                                                                                                                  |
 | get_current_task_info                  | Returns information about the current task.                                                                                                                    |
 | get_current_user                       | Returns the current user.                                                                                                                                      |
+| get_users_assigned_to_task             | Returns all users assigned to the task.                     |
 | get_data_sizes                         | Returns information about the size of task data.                                                                                                               |
 | get_encoded_file_data                  | Returns the encoded file data. This is a very expensive call.                                                                                                  |
 | get_env                                | Returns the current environment (e.g., testing, staging, production).                                                                                          |

--- a/spiffworkflow-backend/src/spiffworkflow_backend/models/human_task.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/models/human_task.py
@@ -28,7 +28,7 @@ class HumanTaskModel(SpiffworkflowBaseDBModel):
     id: int = db.Column(db.Integer, primary_key=True)
     process_instance_id: int = db.Column(ForeignKey(ProcessInstanceModel.id), nullable=False, index=True)  # type: ignore
     lane_assignment_id: int | None = db.Column(ForeignKey(GroupModel.id), index=True)
-    completed_by_user_id: int = db.Column(ForeignKey(UserModel.id), nullable=True, index=True)  # type: ignore
+    completed_by_user_id: int | None = db.Column(ForeignKey(UserModel.id), nullable=True, index=True)  # type: ignore
 
     completed_by_user = relationship("UserModel", foreign_keys=[completed_by_user_id], viewonly=True)
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/scripts/get_users_assigned_to_task.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/scripts/get_users_assigned_to_task.py
@@ -1,0 +1,40 @@
+"""Get users assigned to task."""
+
+from typing import Any
+
+from spiffworkflow_backend.models.db import db
+from spiffworkflow_backend.models.human_task import HumanTaskModel
+from spiffworkflow_backend.models.human_task_user import HumanTaskUserModel
+from spiffworkflow_backend.models.script_attributes_context import ScriptAttributesContext
+from spiffworkflow_backend.models.user import UserModel
+from spiffworkflow_backend.scripts.script import Script
+
+
+class GetUsersAssignedToTask(Script):
+    @staticmethod
+    def requires_privileged_permissions() -> bool:
+        return False
+
+    def get_description(self) -> str:
+        return """Return all users assigned to a task."""
+
+    def run(self, script_attributes_context: ScriptAttributesContext, *_args: Any, **kwargs: Any) -> Any:
+        if _args:
+            task_guid = _args[0]
+        else:
+            task_guid = kwargs.get("task_guid")
+
+        if not task_guid:
+            raise ValueError("Expected task_guid as first argument or keyword argument")
+
+        rows = (
+            db.session.query(UserModel.username)  # type: ignore[no-untyped-call]
+            .join(HumanTaskUserModel, HumanTaskUserModel.user_id == UserModel.id)
+            .join(HumanTaskModel, HumanTaskModel.id == HumanTaskUserModel.human_task_id)
+            .filter(HumanTaskModel.task_guid == task_guid)
+            .distinct()
+            .all()
+        )
+
+        usernames = [r[0] for r in rows]
+        return sorted(usernames)

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/scripts/test_get_users_assigned_to_task.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/scripts/test_get_users_assigned_to_task.py
@@ -80,5 +80,5 @@ class TestGetUsersAssignedToTask(BaseTest):
             process_model_identifier="test_process_model",
         )
 
-        with pytest.raises(ValueError, match="Expected task_guid key argument"):
+        with pytest.raises(ValueError, match="Expected task_guid as first argument or keyword argument"):
             GetUsersAssignedToTask().run(script_attributes_context)

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/scripts/test_get_users_assigned_to_task.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/scripts/test_get_users_assigned_to_task.py
@@ -1,0 +1,84 @@
+import json
+
+import pytest
+from flask.app import Flask
+
+from spiffworkflow_backend.models.db import db
+from spiffworkflow_backend.models.human_task_user import HumanTaskUserModel
+from spiffworkflow_backend.models.script_attributes_context import ScriptAttributesContext
+from spiffworkflow_backend.scripts.get_users_assigned_to_task import GetUsersAssignedToTask
+from spiffworkflow_backend.services.process_instance_processor import ProcessInstanceProcessor
+from tests.spiffworkflow_backend.helpers.base_test import BaseTest
+from tests.spiffworkflow_backend.helpers.test_data import load_test_spec
+
+
+class TestGetUsersAssignedToTask(BaseTest):
+    def test_get_users_assigned_to_task(
+        self,
+        app: Flask,
+        with_db_and_bpmn_file_cleanup: None,
+    ) -> None:
+        user1 = self.find_or_create_user("testuser1")
+        user2 = self.find_or_create_user("testuser2")
+        user3 = self.find_or_create_user("testuser3")
+        db.session.add_all([user1, user2, user3])
+        db.session.commit()
+
+        process_model = load_test_spec(
+            "test_group/hello_world",
+            bpmn_file_name="hello_world.bpmn",
+            process_model_source_directory="hello_world",
+        )
+
+        process_instance = self.create_process_instance_from_process_model(process_model=process_model, user=user1)
+        processor = ProcessInstanceProcessor(process_instance)
+        processor.do_engine_steps(save=True)
+
+        assert len(process_instance.active_human_tasks) == 1
+        human_task = process_instance.active_human_tasks[0]
+
+        # The initiator, user1, is by default assigned as a potential owner for the task
+        assert len(human_task.potential_owners) == 1
+        assert human_task.potential_owners[0] == user1
+
+        # Assign two more potential owners for the same human task
+        db.session.add_all(
+            [
+                HumanTaskUserModel(human_task_id=human_task.id, user_id=user2.id, added_by="manual"),
+                HumanTaskUserModel(human_task_id=human_task.id, user_id=user3.id, added_by="manual"),
+            ]
+        )
+        db.session.commit()
+
+        # Refresh relationship so potential_owners reflects the new join rows
+        db.session.refresh(human_task)
+
+        task_guid = human_task.task_guid
+        assert task_guid is not None
+
+        script_attributes_context = ScriptAttributesContext(
+            task=None,
+            environment_identifier="testing",
+            process_instance_id=process_instance.id,
+            process_model_identifier=process_model.id,
+        )
+
+        result = GetUsersAssignedToTask().run(script_attributes_context, task_guid=task_guid)
+
+        assert result == ["testuser1", "testuser2", "testuser3"]
+        json.dumps(result)
+
+    def test_get_users_assigned_to_task_raises_if_no_task_guid(
+        self,
+        app: Flask,
+        with_db_and_bpmn_file_cleanup: None,
+    ) -> None:
+        script_attributes_context = ScriptAttributesContext(
+            task=None,
+            environment_identifier="testing",
+            process_instance_id=1,
+            process_model_identifier="test_process_model",
+        )
+
+        with pytest.raises(ValueError, match="Expected task_guid key argument"):
+            GetUsersAssignedToTask().run(script_attributes_context)


### PR DESCRIPTION
Cherry picking [work that was merged into sartography main](https://github.com/sartography/spiff-arena/pull/2705) since trying to sync the whole fork right now [seems like a bit of a mess](https://github.com/GSA-TTS/spiff-arena/pull/24). This helps unblock parts of the project details page.

We can use this script to create a BPMN endpoint. When I tested locally, I could see the users assigned to a task as expected. 