### PR TITLE
upgrade trivy-action given trivy's recent security breach

### DIFF
--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Run Trivy vulnerability scanner
         # trivy image --severity CRITICAL --exit-code 1 --timeout 15m0s --ignore-unfixed --scanners vuln "test1:latest"
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@0.34.2
         with:
           image-ref: "${{ steps.full_tag.outputs.full_tag }}"
           scan-type: "image"


### PR DESCRIPTION
Trivy had [a security incident](https://github.com/aquasecurity/trivy/discussions/10265). Our `trivy-action` was attempting to download a now-deleted Trivy binary (v0.65.0). This [upgrades `trivy-action`](https://github.com/aquasecurity/trivy-action/releases/tag/0.34.2) so that it points to a Trivy release that exists (v0.69.2).