### PR TITLE
Bump trivy to non compromised version

### DIFF
--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Run Trivy vulnerability scanner
         # trivy image --severity CRITICAL --exit-code 1 --timeout 15m0s --ignore-unfixed --scanners vuln "test1:latest"
-        uses: aquasecurity/trivy-action@0.34.2
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: "${{ steps.full_tag.outputs.full_tag }}"
           scan-type: "image"


### PR DESCRIPTION
Got this all cleaned up and ready to merge and then hit the trivy issue:
https://github.com/GSA-TTS/spiff-arena/actions/runs/23454080082