### PR TITLE
Upgrade authlib to 1.6.9

### DIFF
--- a/spiffworkflow-backend/pyproject.toml
+++ b/spiffworkflow-backend/pyproject.toml
@@ -62,7 +62,7 @@ dependencies = [
     # https://github.com/pixee/python-security/blob/6256809dac1c45530e5eeef8b48032a2bbd6b7d6/src/security/safe_command/api.py#L640
     "security >= 1.3.1",
     "spiff-arena-common>=0.1.0",
-    "authlib>=1.6.0",
+    "authlib>=1.6.9",
     "starlette>=0.47.2",
     "uvicorn-worker>=0.3.0",
 ]

--- a/spiffworkflow-backend/uv.lock
+++ b/spiffworkflow-backend/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 
 [[package]]
@@ -117,14 +117,14 @@ wheels = [
 
 [[package]]
 name = "authlib"
-version = "1.6.6"
+version = "1.6.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/9b/b1661026ff24bc641b76b78c5222d614776b0c085bcfdac9bd15a1cb4b35/authlib-1.6.6.tar.gz", hash = "sha256:45770e8e056d0f283451d9996fbb59b70d45722b45d854d58f32878d0a40c38e", size = 164894, upload-time = "2025-12-12T08:01:41.464Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/98/00d3dd826d46959ad8e32af2dbb2398868fd9fd0683c26e56d0789bd0e68/authlib-1.6.9.tar.gz", hash = "sha256:d8f2421e7e5980cc1ddb4e32d3f5fa659cfaf60d8eaf3281ebed192e4ab74f04", size = 165134, upload-time = "2026-03-02T07:44:01.998Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/51/321e821856452f7386c4e9df866f196720b1ad0c5ea1623ea7399969ae3b/authlib-1.6.6-py2.py3-none-any.whl", hash = "sha256:7d9e9bc535c13974313a87f53e8430eb6ea3d1cf6ae4f6efcd793f2e949143fd", size = 244005, upload-time = "2025-12-12T08:01:40.209Z" },
+    { url = "https://files.pythonhosted.org/packages/53/23/b65f568ed0c22f1efacb744d2db1a33c8068f384b8c9b482b52ebdbc3ef6/authlib-1.6.9-py2.py3-none-any.whl", hash = "sha256:f08b4c14e08f0861dc18a32357b33fbcfd2ea86cfe3fe149484b4d764c4a0ac3", size = 244197, upload-time = "2026-03-02T07:44:00.307Z" },
 ]
 
 [[package]]
@@ -2846,7 +2846,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "apscheduler", specifier = ">=3.6.0" },
-    { name = "authlib", specifier = ">=1.6.0" },
+    { name = "authlib", specifier = ">=1.6.9" },
     { name = "celery", extras = ["redis", "sqs"], specifier = ">=5.4.0" },
     { name = "celery-stubs", specifier = ">=0.1.3" },
     { name = "chardet", specifier = ">=5.2.0" },


### PR DESCRIPTION
This upgrade addresses https://github.com/GSA-TTS/spiff-arena/security/code-scanning/455. I am hoping it will also unblock this failing action: https://github.com/GSA-TTS/spiff-arena/actions/runs/24044865905/job/70129537959. We need to publish a new image in order to enable HSTS.

