### PR TITLE
Prevents info logs from being 'double wrapped' and mislabeled as err

### DIFF
--- a/connector-proxy-demo/bin/boot_server_in_docker
+++ b/connector-proxy-demo/bin/boot_server_in_docker
@@ -16,4 +16,4 @@ workers=3
 
 # THIS MUST BE THE LAST COMMAND!
 # default --limit-request-line is 4094. see https://stackoverflow.com/a/66688382/6090676
-exec poetry run gunicorn --bind "0.0.0.0:$port" --workers="$workers" --limit-request-line 8192 --timeout 90 --capture-output --access-logfile '-' --log-level debug app:app
+exec poetry run gunicorn --bind "0.0.0.0:$port" --workers="$workers" --limit-request-line 8192 --timeout 90 --capture-output --error-logfile '-' --access-logfile '-' --log-level debug app:app


### PR DESCRIPTION
This should prevent gunicorn logs from going to stderr.

<img width="1348" height="511" alt="image" src="https://github.com/user-attachments/assets/93b571e2-4212-4a67-b815-3afdc79047e6" />
