### PR TITLE
deletes SonarCloud tests since GSA-TTS uses alternative SCA tools; up…

### DIFF
--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -31,7 +31,7 @@ on:
   push:
     branches:
       - main
-      - pic-stable
+      - tts-main
       - bpmn-js-spiffworkflow-react
       - debt/performance
     tags: [v*]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -318,22 +318,6 @@ jobs:
       - name: Upload coverage report
         uses: codecov/codecov-action@v6.0.0
 
-      - name: SonarCloud Scan
-        uses: sonarsource/sonarcloud-github-action@v5.0.0
-        # thought about just skipping dependabot
-        # if: ${{ github.actor != 'dependabot[bot]' }}
-        # but figured all pull requests seems better, since none of them will have access to sonarcloud.
-        # however, with just skipping pull requests, the build associated with "Triggered via push" is also associated with the pull request and also fails hitting sonarcloud
-        # if: ${{ github.event_name != 'pull_request' }}
-        # so just skip everything but main
-        if: github.ref_name == 'main'
-        with:
-          projectBaseDir: spiffworkflow-backend
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      # part about saving PR number and then using it from auto-merge-dependabot-prs from:
-      # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run
       - name: Write PR number to spiffworkflow-backend/pr dir
         if: ${{ github.event_name == 'pull_request' && github.actor == 'dependabot[bot]' }}
         env:
@@ -352,40 +336,6 @@ jobs:
           # trying to explicitly add spiffworkflow-backend to path
           path: spiffworkflow-backend/pr/
           if-no-files-found: error
-
-  tests-frontend:
-    runs-on: ubuntu-latest
-    needs: [tests-backend, run_pre_commit_checks, check_docker_start_script]
-    defaults:
-      run:
-        working-directory: spiffworkflow-frontend
-    steps:
-      - name: Development Code
-        uses: actions/checkout@v6
-        with:
-          # Disabling shallow clone is recommended for improving relevancy of reporting in sonarcloud
-          fetch-depth: 0
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24.x
-      - run: npm install
-      - run: npm run check-ci
-      - run: npm run build --if-present
-      - name: SonarCloud Scan
-        # thought about just skipping dependabot
-        # if: ${{ github.actor != 'dependabot[bot]' }}
-        # but figured all pull requests seems better, since none of them will have access to sonarcloud.
-        # however, with just skipping pull requests, the build associated with "Triggered via push" is also associated with the pull request and also fails hitting sonarcloud
-        # if: ${{ github.event_name != 'pull_request' }}
-        # so just skip everything but main
-        if: github.ref_name == 'main'
-        uses: sonarsource/sonarcloud-github-action@v5.0.0
-        with:
-          projectBaseDir: spiffworkflow-frontend
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   playwright-run:
     runs-on: ubuntu-latest

--- a/README-TTS.md
+++ b/README-TTS.md
@@ -19,5 +19,5 @@
 
    1. recomment that line
 1. commit changes
-1. make a PR that _rebases_ this branch onto `origin/main`
+1. make a PR that _rebases_ this branch onto `origin/tts-main`
 


### PR DESCRIPTION
This PR:
- Deletes SonarCloud tests since GSA-TTS uses alternative SCA tools; 
- Updates the README-TTS to point to the `tts-main` as the new long-lived feature branch.