### PR TITLE
Fix get_current_task_data script (#2767)

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/scripts/get_current_task_data.py
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/scripts/get_current_task_data.py
@@ -1,8 +1,11 @@
 from typing import Any
 
+from SpiffWorkflow.bpmn.serializer import DefaultRegistry  # type: ignore
+
 from spiffworkflow_backend.models.script_attributes_context import ScriptAttributesContext
 from spiffworkflow_backend.scripts.script import Script
-from spiffworkflow_backend.services.bpmn_process_service import BpmnProcessService
+
+_INTERNAL_KEYS = {"__builtins__", "__annotations__"}
 
 
 class GetCurrentTaskData(Script):
@@ -17,5 +20,8 @@ class GetCurrentTaskData(Script):
         """
 
     def run(self, script_attributes_context: ScriptAttributesContext, *_args: Any, **kwargs: Any) -> Any:
-        task_dict = BpmnProcessService.serializer.to_dict(script_attributes_context.task)
-        return task_dict["data"]
+        spiff_task = script_attributes_context.task
+        if not spiff_task:
+            return {}
+        data = DefaultRegistry().convert(spiff_task.data)
+        return {k: v for k, v in data.items() if k not in _INTERNAL_KEYS}

--- a/spiffworkflow-backend/tests/data/get_current_task_data/get_current_task_data.bpmn
+++ b/spiffworkflow-backend/tests/data/get_current_task_data/get_current_task_data.bpmn
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_96f6665" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.0.0-dev">
+  <bpmn:process id="Process_a_script_test_s5cy1r2" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_17db3yp</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_17db3yp" sourceRef="StartEvent_1" targetRef="Activity_1273403" />
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_0320nib</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0rpi4ug" sourceRef="Activity_1273403" targetRef="Activity_03owewc" />
+    <bpmn:scriptTask id="Activity_1273403" name="script task 1">
+      <bpmn:incoming>Flow_17db3yp</bpmn:incoming>
+      <bpmn:outgoing>Flow_0rpi4ug</bpmn:outgoing>
+      <bpmn:script>c = 3</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="Flow_0320nib" sourceRef="Activity_03owewc" targetRef="EndEvent_1" />
+    <bpmn:scriptTask id="Activity_03owewc" name="get task data">
+      <bpmn:incoming>Flow_0rpi4ug</bpmn:incoming>
+      <bpmn:outgoing>Flow_0320nib</bpmn:outgoing>
+      <bpmn:script>a = get_current_task_data()</bpmn:script>
+    </bpmn:scriptTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_a_script_test_s5cy1r2">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0f0776w_di" bpmnElement="Activity_1273403">
+        <dc:Bounds x="270" y="137" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1oeatr3_di" bpmnElement="Activity_03owewc">
+        <dc:Bounds x="470" y="137" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_14za570_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="652" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_17db3yp_di" bpmnElement="Flow_17db3yp">
+        <di:waypoint x="215" y="177" />
+        <di:waypoint x="270" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0rpi4ug_di" bpmnElement="Flow_0rpi4ug">
+        <di:waypoint x="370" y="177" />
+        <di:waypoint x="470" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0320nib_di" bpmnElement="Flow_0320nib">
+        <di:waypoint x="570" y="177" />
+        <di:waypoint x="652" y="177" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/spiffworkflow-backend/tests/spiffworkflow_backend/scripts/test_get_current_task_data.py
+++ b/spiffworkflow-backend/tests/spiffworkflow_backend/scripts/test_get_current_task_data.py
@@ -1,0 +1,25 @@
+from flask.app import Flask
+
+from spiffworkflow_backend.services.process_instance_processor import ProcessInstanceProcessor
+from tests.spiffworkflow_backend.helpers.base_test import BaseTest
+from tests.spiffworkflow_backend.helpers.test_data import load_test_spec
+
+
+class TestGetCurrentTaskData(BaseTest):
+    def test_get_current_task_data_through_bpmn(
+        self,
+        app: Flask,
+        with_db_and_bpmn_file_cleanup: None,
+    ) -> None:
+        initiator_user = self.find_or_create_user("initiator_user")
+        process_model = load_test_spec(
+            process_model_id="test_group/get_current_task_data",
+            bpmn_file_name="get_current_task_data.bpmn",
+            process_model_source_directory="get_current_task_data",
+        )
+        process_instance = self.create_process_instance_from_process_model(process_model=process_model, user=initiator_user)
+        processor = ProcessInstanceProcessor(process_instance)
+        processor.do_engine_steps(save=True)
+
+        data = ProcessInstanceProcessor._default_script_engine.environment.last_result()
+        assert data["a"] == {"c": 3}


### PR DESCRIPTION
This fix comes from sartography:

get_current_task_data was broken due to changes in the serialzer, for this case, we just bypass the serializer and use Spiff's default registry to convert the task data to a dictionary.