### PR TITLE
Add unauthorized user to pic_test.yml

### DIFF
--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/permissions/pic_test.yml
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/permissions/pic_test.yml
@@ -1,78 +1,22 @@
+# Only put bootstrap users in here
+# Other users should be defined via DMN or IDP groups
+
 users:
-  approver:
-    service: local_open_id
-    email: approver@example.com
-    password: approver
-    preferred_username: approver
-  specialist:
-    service: local_open_id
-    email: specialist@example.com
-    password: specialist
-    preferred_username: specialist
-  reviewer:
-    service: local_open_id
-    email: reviewer@example.com
-    password: reviewer
-    preferred_username: reviewer
-  supervisor:
-    service: local_open_id
-    email: supervisor@example.com
-    password: supervisor
-    preferred_username: supervisor
-  analyst:
-    service: local_open_id
-    email: analyst@example.com
-    password: analyst
-    preferred_username: analyst
   admin:
     service: local_open_id
     email: admin@example.com
     password: admin
     preferred_username: admin
-  unauthorized:
-    service: local_open_id
-    email: unauthorized@example.com
-    password: unauthorized
-    preferred_username: unauthorized
   adminX:
     service: bootstrap
 
 groups:
   admin:
-    users: [ admin@example.com, adminX@bootstrap ]
-  blm-moab:
-    users: [ specialist@example.com ]
-  blm-moab-ao:
-    users: [ approver@example.com ]
-  blm-moab-nepa-coord:
-    users: [ reviewer@example.com ]
-  blm-moab-supervisors:
-    users: [ supervisor@example.com ]
+    users: [admin@example.com, adminX@bootstrap]
 
 permissions:
   # Admins have access to everything.
   admin:
-    groups: [ admin ]
-    actions: [ all ]
+    groups: [admin]
+    actions: [all]
     uri: /*
-
-  # Everybody can participate in tasks assigned to them.
-  # BASIC, PG, PM, are documented at https://spiff-arena.readthedocs.io/en/latest/DevOps_installation_integration/permission_url.html
-  basic:
-    groups: [ everybody ]
-    actions: [ all ]
-    uri: BASIC
-
-  # Everyone can see everything (all groups, and processes are visible)
-  read-all-process-groups:
-    groups: [ everybody ]
-    actions: [ read ]
-    uri: PG:ALL
-  read-all-process-models:
-    groups: [ everybody ]
-    actions: [ read ]
-    uri: PM:ALL
-  run-all-process-models:
-    groups: [ everybody ]
-    actions: [ start ]
-    uri: PM:ALL

--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/permissions/pic_test.yml
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/permissions/pic_test.yml
@@ -29,6 +29,11 @@ users:
     email: admin@example.com
     password: admin
     preferred_username: admin
+  unauthorized:
+    service: local_open_id
+    email: unauthorized@example.com
+    password: unauthorized
+    preferred_username: unauthorized
   adminX:
     service: bootstrap
 

--- a/spiffworkflow-backend/src/spiffworkflow_backend/config/permissions/pic_test.yml
+++ b/spiffworkflow-backend/src/spiffworkflow_backend/config/permissions/pic_test.yml
@@ -1,18 +1,53 @@
-# Only put bootstrap users in here
-# Other users should be defined via DMN or IDP groups
-
 users:
+  approver:
+    service: local_open_id
+    email: approver@example.com
+    password: approver
+    preferred_username: approver
+  specialist:
+    service: local_open_id
+    email: specialist@example.com
+    password: specialist
+    preferred_username: specialist
+  reviewer:
+    service: local_open_id
+    email: reviewer@example.com
+    password: reviewer
+    preferred_username: reviewer
+  supervisor:
+    service: local_open_id
+    email: supervisor@example.com
+    password: supervisor
+    preferred_username: supervisor
+  analyst:
+    service: local_open_id
+    email: analyst@example.com
+    password: analyst
+    preferred_username: analyst
   admin:
     service: local_open_id
     email: admin@example.com
     password: admin
     preferred_username: admin
+  unauthorized:
+    service: local_open_id
+    email: unauthorized@example.com
+    password: unauthorized
+    preferred_username: unauthorized
   adminX:
     service: bootstrap
 
 groups:
   admin:
     users: [admin@example.com, adminX@bootstrap]
+  blm-moab:
+    users: [specialist@example.com]
+  blm-moab-ao:
+    users: [approver@example.com]
+  blm-moab-nepa-coord:
+    users: [reviewer@example.com]
+  blm-moab-supervisors:
+    users: [supervisor@example.com]
 
 permissions:
   # Admins have access to everything.


### PR DESCRIPTION
This PR does two things:

1. It sets up a new unauthorized user for CI tests to use.
2. It gets rid of all non-admin permissions in our config file. The only permissions we should be setting should be from our application in DMN tables. That keeps us consistent and reduces the likelihood of deployed vs. local mismatches.

In https://github.com/GSA-TTS/pic-blm-cxworks/pull/939, we create the same user for the local keycloak auth server, and we update permissions for everybody--namely, no permissions.

This PR needs to be in place for https://github.com/GSA-TTS/pic-blm-cxworks/pull/939 to add a test related to it.